### PR TITLE
Fix fatal error when running with --check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,7 +37,7 @@
       shell: . ~/.profile && nvm alias default {{ nvm.node_version }} --no-colors
       args:
         executable: /bin/bash
-      when: "'default -> {{ nvm.node_version }}' not in nvm_check_default.stdout"
+      when: "('default -> ' ~ nvm.node_version) not in nvm_check_default.stdout|default('')"
 
     become_user: "{{ nvm.user }}"
 


### PR DESCRIPTION
When running ansible-playbook --check, the "check if X is the default version" task is skipped because it's a shell command. This causes the "when" expression in the following task to fail because there is no shell output to search.